### PR TITLE
feat: ISO time output in podcast list

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -202,8 +202,6 @@ const main = async () => {
     getFolderName({ feed, template: outDir })
   );
 
-  logFeedInfo(feed);
-
   if (list) {
     if (feed.items && feed.items.length) {
       const listFormat = typeof list === "boolean" ? "table" : list;
@@ -225,6 +223,12 @@ const main = async () => {
   if (info || list) {
     process.exit(0);
   }
+
+  /**
+  LogFeedInfo is moved here because we don't want to have stdout contain anything other than the JSON or table
+  */
+
+  logFeedInfo(feed);
 
   if (!fs.existsSync(basePath)) {
     logMessage(`${basePath} does not exist. Creating...`, LOG_LEVELS.important);

--- a/bin/util.js
+++ b/bin/util.js
@@ -364,6 +364,7 @@ const logItemsList = ({
       title: item.title,
       pubDate: item.pubDate,
       pubTimeISO: dayjs(new Date(item.pubDate)).toISOString(),
+      guid: item.guid,
     };
   });
 

--- a/bin/util.js
+++ b/bin/util.js
@@ -363,6 +363,7 @@ const logItemsList = ({
       episodeNum: feed.items.length - item._originalIndex,
       title: item.title,
       pubDate: item.pubDate,
+      pubTimeISO: dayjs(new Date(item.pubDate)).toISOString(),
     };
   });
 


### PR DESCRIPTION
This PR added ISO time output in the `--list` mode, which is useful for us to retrieve the metadata (titles, timestamps) list of audios to pull before the actual download. We also made timestamp to be output in ISO format in `pubTimeISO` field to have better consistency with other tools.


### Sample output

```
2022-12-04 00:18:05.668 | DEBUG    | __main__:make_cmd_list_podcast:105 - Generated podcast-dl CLI command: npx ~/sideProjects/podcast-dl --url https://anchor.fm/s/2578d5a0/podcast/rss --list json --after 2022-05-25 --limit 1
2022-12-04T00:18:05.668352
[{'episodeNum': 37, 'title': 'The Merge (Part 2) - with Stephane Gosselin, Danny Ryan, Tim Beiko, and Hasu', 'pubDate': 'Wed, 25 May 2022 09:46:47 GMT', 'pubTimeISO': '2022-05-25T09:46:47.000Z', 'guid': '84911655-cd16-4535-9277-9f647b9b592d'}]
```